### PR TITLE
Update API endpoint for loading user info

### DIFF
--- a/pakkujs/injected/panel.js
+++ b/pakkujs/injected/panel.js
@@ -134,7 +134,7 @@ function _load_info(uid,logger,callback) {
     }
     var xhr=new XMLHttpRequest();
     xhr.responseType='text';
-    xhr.open('get','https://api.bilibili.com/cardrich?type=json&mid='+uid);
+    xhr.open('get','https://api.bilibili.com/x/web-interface/card?type=json&mid='+uid);
     xhr.onreadystatechange=function() {
         if(this.readyState!=4) return;
         var res;
@@ -166,7 +166,7 @@ function query_uid(uidhash,logger) {
                 _load_info(uid,subitem,function(res) {
                     var nickname,lv,exp,regtime;
                     
-                    if(!res.data) { // does not exist
+                    if(!res.data || !res.data.card || !res.data.card.mid) { // does not exist
                         subitem.parentNode.removeChild(subitem);
                         return;
                     }


### PR DESCRIPTION
The old API now returns `[]` for all requests.

Note that when passed in a nonexistent user id, the API response still shares the same structure except that most fields will be empty (e.g. https://api.bilibili.com/x/web-interface/card?mid=404404404404&type=json).