### PR TITLE
use average time

### DIFF
--- a/pakkujs/core/core.js
+++ b/pakkujs/core/core.js
@@ -312,7 +312,10 @@ function parse(ir,tabid,S,D) {
                 var representative=dm.peers[
                     Math.min(Math.floor(dm.peers.length*REPRESENTATIVE_PERCENT/100),dm.peers.length-1)
                 ];
-                dm.time=representative.ir_obj.time_ms/1000;
+                var total_time_ms=0;
+                for (const item of dm.peers)
+                    total_time_ms+=item.time_ms;
+                dm.time=total_time_ms/dm.peers.length/1000;
                 dm.mode=representative.ir_obj.mode;
                 dm.size=representative.ir_obj.fontsize;
                 dm.ir_obj=representative.ir_obj;


### PR DESCRIPTION
合并弹幕后，合并的弹幕总是会提前出现，导致观感变差；
合并的弹幕大致会呈正态分布，我觉得如果取它的事件的均值，一般来说会刚好在正确的时间吧？

我不是很熟悉js【可能会有错误QWQ